### PR TITLE
Bento: checksum name support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,7 @@ you can use this shorthand,
 ```json
 {
   "blobpack": {
-    "artifacts": [
-      "boring"
-    ]
+    "artifacts": ["boring"]
   }
 }
 ```
@@ -143,9 +141,23 @@ you can use the `include` property,
     "include": {
       "resources": ["logger"]
     },
-    "artifacts": [
-      "boring"
-    ]
+    "artifacts": ["boring"]
+  }
+}
+```
+
+#### Bento support
+
+If you need Serverless Bento, you can change `src` and `checksumPrefix` properties:
+
+```json
+{
+  "blobpack": {
+    "name": "benthos-lambda",
+    "version": "4.10.0",
+    "platform": "linux_amd64",
+    "checksumPrefix": "bento",
+    "src": "https://github.com/warpstreamlabs/bento/releases/download"
   }
 }
 ```

--- a/lib/config.js
+++ b/lib/config.js
@@ -10,6 +10,10 @@ export const loadConfig = async (configPath) => {
     )
   }
 
+  if (typeof config.checksum === 'undefined') {
+    config.checksum = 'benthos'
+  }
+
   return config
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -10,8 +10,8 @@ export const loadConfig = async (configPath) => {
     )
   }
 
-  if (typeof config.checksum === 'undefined') {
-    config.checksum = 'benthos'
+  if (typeof config.checksumPrefix === 'undefined') {
+    config.checksumPrefix = 'benthos'
   }
 
   return config

--- a/lib/install.js
+++ b/lib/install.js
@@ -38,7 +38,9 @@ const get = async (benthos) => {
 
   const [data, checksums] = await Promise.all([
     download(`${root}/${name}`),
-    download(`${root}/${benthos.checksum}_${benthos.version}_checksums.txt`)
+    download(
+      `${root}/${benthos.checksumPrefix}_${benthos.version}_checksums.txt`
+    )
   ])
 
   return { name, data, checksums }

--- a/lib/install.js
+++ b/lib/install.js
@@ -38,7 +38,7 @@ const get = async (benthos) => {
 
   const [data, checksums] = await Promise.all([
     download(`${root}/${name}`),
-    download(`${root}/benthos_${benthos.version}_checksums.txt`)
+    download(`${root}/${benthos.checksum}_${benthos.version}_checksums.txt`)
   ])
 
   return { name, data, checksums }


### PR DESCRIPTION
This adds a config option to name the checksum file, which then supports downloading [Bento](https://github.com/warpstreamlabs/bento)